### PR TITLE
Fail when badge is not created

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,9 @@ try {
         }
       },
       res => {
+        if (res.statusCode < 200 || res.statusCode >= 400) {
+            core.setFailed('Failed to create gist, response status code: ' +  res.statusCode + ', status message: ' +  res.statusMessage);
+        }
         let body = '';
         res.on('data', data => body += data);
         res.on('end', () => console.log('result:' + body));


### PR DESCRIPTION
The action was not failing when the authorization was not set.  As well when used in a matrix causes concurrent updates of the gist, causing a 500 response code. 

The action should fail when the badge info was not success full updated