### PR TITLE
Added a new feature to allow a color range

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Gist Parameter | Description
 `maxColorRange` | Maximum value in the range used to define the message color.
 `minColorRange` | Minimum value in the range used to define the message color.
 `invertColorRange` | If the range should be inverted, causing a smaller value to have green color.
-  `colorRangeSaturation` |  Saturation used by the color range feature. Defaults to 100%.
-  `colorRangeLightness` |  Lightness used by the color range feature. Defaults to 40%.
+`colorRangeSaturation` |  Saturation used by the color range feature. Defaults to 100%.
+`colorRangeLightness` |  Lightness used by the color range feature. Defaults to 40%.
 
 ### Using Environment Variables as Parameters [![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/schneegans/2ab8f1d386f13aaebccbd87dac94068d/raw/answer.json)](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/schneegans/2ab8f1d386f13aaebccbd87dac94068d/raw/answer.json)
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Gist Parameter | Description
 `maxColorRange` | Maximum value in the range used to define the message color.
 `minColorRange` | Minimum value in the range used to define the message color.
 `invertColorRange` | If the range should be inverted, causing a smaller value to have green color.
+  `colorRangeSaturation` |  Saturation used by the color range feature. Defaults to 100%.
+  `colorRangeLightness` |  Lightness used by the color range feature. Defaults to 40%.
 
 ### Using Environment Variables as Parameters [![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/schneegans/2ab8f1d386f13aaebccbd87dac94068d/raw/answer.json)](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/schneegans/2ab8f1d386f13aaebccbd87dac94068d/raw/answer.json)
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ Gist Parameter | Description
 `logoPosition` | The position of the logo.
 `style` | The style like "flat" or "social".
 `cacheSeconds` | The cache lifetime in seconds (must be greater than 300).
-`maxColorRange` | Maximum value for the value passaed as message. Used to define the message color. 
-`minColorRange` | Minimum value for the value passaed as message. Used to define the message color.
+`valColorRange` | Numerical value used to define the message color.
+`maxColorRange` | Maximum value in the range used to define the message color.
+`minColorRange` | Minimum value in the range used to define the message color.
+`invertColorRange` | If the range should be inverted, causing a smaller value to have green color.
 
 ### Using Environment Variables as Parameters [![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/schneegans/2ab8f1d386f13aaebccbd87dac94068d/raw/answer.json)](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/schneegans/2ab8f1d386f13aaebccbd87dac94068d/raw/answer.json)
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Gist Parameter | Description
 `logoPosition` | The position of the logo.
 `style` | The style like "flat" or "social".
 `cacheSeconds` | The cache lifetime in seconds (must be greater than 300).
+`maxColorRange` | Maximum value for the value passaed as message. Used to define the message color. 
+`minColorRange` | Minimum value for the value passaed as message. Used to define the message color.
 
 ### Using Environment Variables as Parameters [![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/schneegans/2ab8f1d386f13aaebccbd87dac94068d/raw/answer.json)](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/schneegans/2ab8f1d386f13aaebccbd87dac94068d/raw/answer.json)
 

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,12 @@ inputs:
   invertColorRange:
     description: 'If the range should be inverted, causing a smaller value to have green color.'
     required: false
+  colorRangeSaturation:
+    description: 'Saturation used by the color range feature. Defaults to 100%.'
+    required: false
+  colorRangeLightness:
+    description: 'Lightness used by the color range feature. Defaults to 40%.
+    required: false
 runs:
   using: 'node12'
   main: 'index.js'

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,12 @@ inputs:
   cacheSeconds:
     description: 'The cache lifetime in seconds (must be greater than 300)'
     required: false
+  maxColorRange:
+    description: 'Maximum value for the value passaed as message. Used to define the message color.'
+    required: false
+  minColorRange:
+    description: 'Minimum value for the value passaed as message. Used to define the message color.'
+    required: false
 runs:
   using: 'node12'
   main: 'index.js'

--- a/action.yml
+++ b/action.yml
@@ -49,11 +49,17 @@ inputs:
   cacheSeconds:
     description: 'The cache lifetime in seconds (must be greater than 300)'
     required: false
+  valColorRange:
+    description: 'Numerical value used to define the message color.'
+    required: false
   maxColorRange:
-    description: 'Maximum value for the value passaed as message. Used to define the message color.'
+    description: 'Maximum value in the range used to define the message color.'
     required: false
   minColorRange:
-    description: 'Minimum value for the value passaed as message. Used to define the message color.'
+    description: 'Minimum value in the range used to define the message color.'
+    required: false
+  invertColorRange:
+    description: 'If the range should be inverted, causing a smaller value to have green color.'
     required: false
 runs:
   using: 'node12'

--- a/index.js
+++ b/index.js
@@ -41,11 +41,9 @@ try {
     if (val > max) val = max;
     let hue = 0
     if (invertColorRange == '') {
-      hue = Math.floor((val - min) / (max - min) * 100);
-      content.message = val + " / " + max + " " + content.message
+      hue = Math.floor((val - min) / (max - min) * 120);
     } else {
-      hue = Math.floor((max - val) / (max - min) * 100);
-      content.message = valColorRange + " " + content.message
+      hue = Math.floor((max - val) / (max - min) * 120);
     }
     content.color = "hsl(" + hue + ", 100%, 50%)";
   } else if (color != '') {

--- a/index.js
+++ b/index.js
@@ -42,10 +42,10 @@ try {
     var hue = 0
     if (invertColorRange == '') {
       hue = Math.floor((val - min) / (max - min) * 100);
-      message = val + " / " + max + " " + message
+      content.message = val + " / " + max + " " + content.message
     } else {
       hue = Math.floor((max - val) / (max - min) * 100);
-      message = val + " " + message
+      content.message = val + " " + content.message
     }
     content.color = "hsl(" + hue + ", 100%, 50%)";
   } else if (color != '') {

--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ try {
   const minColorRange = core.getInput('minColorRange');
   const maxColorRange = core.getInput('maxColorRange');
   const invertColorRange = core.getInput('invertColorRange');
+  const colorRangeSaturation = core.getInput('colorRangeSaturation');
+  const colorRangeLightness = core.getInput('colorRangeLightness');
 
   if (labelColor != '') {
     content.labelColor = labelColor;
@@ -39,13 +41,21 @@ try {
     const val = parseFloat(valColorRange);
     if (val < min) val = min;
     if (val > max) val = max;
-    let hue = 0
+    let hue = 0;
     if (invertColorRange == '') {
       hue = Math.floor((val - min) / (max - min) * 120);
     } else {
       hue = Math.floor((max - val) / (max - min) * 120);
     }
-    content.color = "hsl(" + hue + ", 100%, 40%)";
+    let sat = 100;
+    if(colorRangeSaturation != '') {
+      sat = colorRangeSaturation;
+    } 
+    let lig = 40;
+    if(colorRangeLightness != '') {
+      lig = colorRangeLightness;
+    }
+    content.color = "hsl(" + hue + ", " + sat +  "%, " + lig + "%)";
   } else if (color != '') {
     content.color = color;
   }

--- a/index.js
+++ b/index.js
@@ -24,20 +24,29 @@ try {
   const logoPosition = core.getInput('logoPosition');
   const style        = core.getInput('style');
   const cacheSeconds = core.getInput('cacheSeconds');
+  const valColorRange = core.getInput('valColorRange');
   const minColorRange = core.getInput('minColorRange');
   const maxColorRange = core.getInput('maxColorRange');
+  const invertColorRange = core.getInput('invertColorRange');
 
   if (labelColor != '') {
     content.labelColor = labelColor;
   }
 
-  if (minColorRange != '' && maxColorRange != '') {
+  if (minColorRange != '' && maxColorRange != '' && valColorRange != '') {
     var max = parseFloat(maxColorRange);
     var min = parseFloat(minColorRange);
-    var val = parseFloat(content.message);
+    var val = parseFloat(valColorRange);
     if (val < min) val = min;
     if (val > max) val = max;
-    let hue = Math.floor((val - min) / (max - min) * 100);
+    var hue = 0
+    if (invertColorRange == '') {
+      hue = Math.floor((val - min) / (max - min) * 100);
+      message = val + " / " + max + " " + message
+    } else {
+      hue = Math.floor((max - val) / (max - min) * 100);
+      message = val + " " + message
+    }
     content.color = "hsl(" + hue + ", 100%, 50%)";
   } else if (color != '') {
     content.color = color;

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ try {
     } else {
       hue = Math.floor((max - val) / (max - min) * 120);
     }
-    content.color = "hsl(" + hue + ", 100%, 50%)";
+    content.color = "hsl(" + hue + ", 100%, 40%)";
   } else if (color != '') {
     content.color = color;
   }

--- a/index.js
+++ b/index.js
@@ -24,12 +24,22 @@ try {
   const logoPosition = core.getInput('logoPosition');
   const style        = core.getInput('style');
   const cacheSeconds = core.getInput('cacheSeconds');
+  const minColorRange = core.getInput('minColorRange');
+  const maxColorRange = core.getInput('maxColorRange');
 
   if (labelColor != '') {
     content.labelColor = labelColor;
   }
 
-  if (color != '') {
+  if (minColorRange != '' && maxColorRange != '') {
+    var max = parseFloat(maxColorRange);
+    var min = parseFloat(minColorRange);
+    var val = parseFloat(content.message);
+    if (val < min) val = min;
+    if (val > max) val = max;
+    let hue = Math.floor((val - min) / (max - min) * 100);
+    content.color = "hsl(" + hue + ", 100%, 50%)";
+  } else if (color != '') {
     content.color = color;
   }
 

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ try {
       content.message = val + " / " + max + " " + content.message
     } else {
       hue = Math.floor((max - val) / (max - min) * 100);
-      content.message = val + " " + content.message
+      content.message = valColorRange + " " + content.message
     }
     content.color = "hsl(" + hue + ", 100%, 50%)";
   } else if (color != '') {

--- a/index.js
+++ b/index.js
@@ -34,12 +34,12 @@ try {
   }
 
   if (minColorRange != '' && maxColorRange != '' && valColorRange != '') {
-    var max = parseFloat(maxColorRange);
-    var min = parseFloat(minColorRange);
-    var val = parseFloat(valColorRange);
+    const max = parseFloat(maxColorRange);
+    const min = parseFloat(minColorRange);
+    const val = parseFloat(valColorRange);
     if (val < min) val = min;
     if (val > max) val = max;
-    var hue = 0
+    let hue = 0
     if (invertColorRange == '') {
       hue = Math.floor((val - min) / (max - min) * 100);
       content.message = val + " / " + max + " " + content.message


### PR DESCRIPTION
Hi,
I added a feature in this fork that allows the user to define a range and provide a value using 3 new arguments, 'min', 'max' and 'value'. I felt the need of having such feature when running workflows that provided a score and not just a pass/fail response, such as pylint.
The new section in the index.json file makes sure the value provided is within the range and calculate a color betwen green and red, providing a HSL value to shield.io, besides also formating the resulting message.
One last parameter was added, which allows the user to invert the range, making the smaller value green, and a bigger one, red. This is useful for tests that return number of error, such as flake 8