### PR TITLE
:tada: add the ability to update gist only if changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Parameter | Description
 `logoPosition` | The position of the logo.
 `style` | The style like "flat" or "social".
 `cacheSeconds` | The cache lifetime in seconds (must be greater than 300).
+`updateIfChanged` | Default is `false`. If `true` will update the gist only if content changed.
 
 ### Color Range Parameters (optional)
 

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
   message:
     description: 'The right text of the badge'
     required: true
+  updateIfChanged:
+    description: 'If true will update the gist only if content changed'
+    default: 'false'
+    required: false
   labelColor:
     description: 'The left color of the badge'
     required: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-badges-action",
-  "version": "1.0.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/Schneegans/dynamic-badges-action/issues"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-badges-action",
-  "version": "1.0.0",
+  "version": "1.5.0",
   "description": "A GitHub Action which uses shields.io to create custom badges and uploads the to a gist.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
:tada: add the ability to update gist only if changed

I really like your action and I'm using it a lot in my projects.
I decided to contribute to this really cool feature.
I tried to keep your style and convention.
I added documentation and test my branch with all possible options, you can view it [here](https://github.com/MishaKav/api-testing-example/actions/workflows/dynamic-badges-action.yml) 

**`updateIfChanged` Feature:**
- add a new property `updateIfChanged: true`
- the default is `false` which gives backward compatibility
- documentation updated
